### PR TITLE
Update runtime to 6.9, add QtWebEngineProcess env

### DIFF
--- a/org.kde.ghostwriter.json
+++ b/org.kde.ghostwriter.json
@@ -13,7 +13,8 @@
         "--socket=pulseaudio",
         "--share=ipc",
         "--share=network",
-        "--device=dri"
+        "--device=dri",
+        "--env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess"
     ],
     "cleanup-commands": [
         "/app/cleanup-BaseApp.sh"

--- a/org.kde.ghostwriter.json
+++ b/org.kde.ghostwriter.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.kde.ghostwriter",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.8",
+    "runtime-version": "6.9",
     "base": "io.qt.qtwebengine.BaseApp",
-    "base-version": "6.8",
+    "base-version": "6.9",
     "sdk": "org.kde.Sdk",
     "command": "ghostwriter",
     "rename-icon": "ghostwriter",


### PR DESCRIPTION
I am not sure if the `--env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess` argument is necessary in practice, but the documentation says so